### PR TITLE
The actions “prefix remove” does not trigger the onChange event and initialize the assignment

### DIFF
--- a/desktop/src/component/action/ProxyActionEditor.tsx
+++ b/desktop/src/component/action/ProxyActionEditor.tsx
@@ -121,6 +121,7 @@ export const ProxyActionEditor: React.FunctionComponent<{
           <div>
             <Input
               placeholder={"example: /api"}
+              value={typeof action.prefixRemove === 'string' ? action.prefixRemove : undefined}
               onChange={(event) => {
                 actionContext.onActionModify({
                   ...action,

--- a/frontEnd/src/component/action/ProxyActionEditor.tsx
+++ b/frontEnd/src/component/action/ProxyActionEditor.tsx
@@ -117,7 +117,16 @@ export const ProxyActionEditor: React.FunctionComponent<{
         <div className={moduleStyle.row}>
           <div>prefix remove</div>
           <div>
-            <Input placeholder={'example: /api'}/>
+            <Input
+                placeholder={"example: /api"}
+                value={typeof action.prefixRemove === 'string' ? action.prefixRemove : undefined}
+                onChange={(event) => {
+                  actionContext.onActionModify({
+                    ...action,
+                    prefixRemove: event.target.value,
+                  });
+                }}
+            />
           </div>
         </div>
         <div className={moduleStyle.row}>


### PR DESCRIPTION
<img width="324" alt="image" src="https://github.com/alinGmail/LiveMock/assets/2438900/23baa5ab-6a8a-48fc-8d1e-7b95f1c16662">

Hi, alin.

I found some bugs when using the prefix remove function, I just pulled a branch to fix it, please make sure it's ok and merge it in?

I think livemock is a very useful tool, I hope you can consider adding the ability to separate different projects by user dimension in subsequent versions.

Thanks.